### PR TITLE
do not print list using warn()

### DIFF
--- a/sphinxcontrib/ditaa.py
+++ b/sphinxcontrib/ditaa.py
@@ -127,7 +127,6 @@ def render_ditaa(self, code, options, prefix='ditaa'):
     f.close()
 
     try:
-        self.builder.warn(ditaa_args)
         p = Popen(ditaa_args, stdout=PIPE, stdin=PIPE, stderr=PIPE)
     except OSError as err:
         if err.errno != ENOENT:   # No such file or directory


### PR DESCRIPTION
otherwise we will have
```
Exception occurred:
  File "/home/jenkins-build/build/workspace/ceph-pr-docs/build-doc/virtualenv/local/lib/python2.7/site-packages/sphinx/util/logging.py", line 338, in filter
    raise SphinxWarning(record.msg % record.args)
TypeError: unsupported operand type(s) for %: 'list' and 'tuple'
```

when running `sphinx-build` with `-W` (turn warnings into error),  where the `list` is`ditaa_args`, and `tuple` is empty.