### PR TITLE
fix UnicodeEncodeError when loading utf-8 ditaa file with python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requires = ['Sphinx>=1.0']
 
 setup(
     name='sphinx-ditaa',
-    version='0.1',
+    version='0.2',
     url='https://github.com/baloo/sphinx-ditaa',
     license='BSD License',
     author='Arthur Gautier',

--- a/sphinxcontrib/ditaa.py
+++ b/sphinxcontrib/ditaa.py
@@ -11,6 +11,9 @@
     :license: BSD, see LICENSE for details.
 """
 
+# for python2, to behave like python3 (all str are unicode).
+from __future__ import unicode_literals
+
 import re
 import codecs
 import posixpath
@@ -28,7 +31,6 @@ from docutils.parsers.rst import directives
 from sphinx.errors import SphinxError
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE
 from sphinx.util.compat import Directive
-
 
 mapname_re = re.compile(r'<map id="(.*?)"')
 svg_dim_re = re.compile(r'<svg\swidth="(\d+)pt"\sheight="(\d+)pt"', re.M)
@@ -113,7 +115,7 @@ def render_ditaa(self, code, options, prefix='ditaa'):
     ensuredir(path.dirname(outfullfn))
 
     # ditaa expects UTF-8 by default
-    if isinstance(code, str):
+    if isinstance(code, unicode):
         code = code.encode('utf-8')
 
     ditaa_args = [self.builder.config.ditaa]


### PR DESCRIPTION
With python 2.7, I was still having an : " Encoding error:
'ascii' codec can't encode character u'\xb9' in position 59: ordinal not in range(128) "

Fixed without using sys.setdefaultencoding('utf8').

NB: Sorry to bother you with another pull request, I do think this one doesn't imply any maintaining task.
(and I really dislike using debian/patches :) ).