### PR TITLE
Fixes #14: Directive now imported directly from docutils.parsers.rst

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,5 @@
+The ditaa Sphinx extension is written by Arthur Gautier.
+
+Other contributors, listed alphabetically, are:
+
+* Antti Kaihola -- Sphinx 1.7 compatibility bug fix

--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,7 @@
+Release 0.3 (in development)
+============================
+
+Bugs fixed
+----------
+
+* #14: import ``Directive`` directly from ``docutils.parsers.rst``

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requires = ['Sphinx>=1.0']
 
 setup(
     name='sphinx-ditaa',
-    version='0.2',
+    version='0.3.dev',
     url='https://github.com/baloo/sphinx-ditaa',
     license='BSD License',
     author='Arthur Gautier',

--- a/sphinxcontrib/ditaa.py
+++ b/sphinxcontrib/ditaa.py
@@ -26,11 +26,10 @@ except ImportError:
     from sha import sha
 
 from docutils import nodes
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import Directive, directives
 
 from sphinx.errors import SphinxError
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE
-from sphinx.util.compat import Directive
 
 import sys
 


### PR DESCRIPTION
Sphinx 1.7 no longer provides the `Directive` class through `sphinx.util.compat`.

This fix was originally included in fac65da4b64794c1d1c8bc57a10a531244510710 by Sylvain Delisle, but that commit was never merged upstream.

Also added the change and its author in the new `CHANGES` and `AUTHORS` files and bumped the version number to 0.3.dev.